### PR TITLE
add watch

### DIFF
--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -10,6 +10,9 @@ mod broadcast;
 pub use broadcast::BroadcastStream;
 pub use broadcast::BroadcastStreamRecvError;
 
+mod watch;
+pub use watch::WatchStream;
+
 cfg_time! {
     mod interval;
     pub use interval::IntervalStream;

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -7,9 +7,9 @@ use tokio::sync::broadcast::Receiver;
 use std::fmt;
 use std::task::{Context, Poll};
 
-/// A wrapper around [`Receiver`] that implements [`Stream`].
+/// A wrapper around [`tokio::sync::broadcast::Receiver`] that implements [`Stream`].
 ///
-/// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
+/// [`tokio::sync::broadcast::Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
 pub struct BroadcastStream<T> {
     inner: Pin<Box<dyn Stream<Item = Result<T, BroadcastStreamRecvError>> + Send + Sync>>,

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -1,0 +1,49 @@
+use crate::Stream;
+use async_stream::stream;
+use std::pin::Pin;
+use tokio::sync::watch::error::RecvError;
+use tokio::sync::watch::Receiver;
+
+use std::fmt;
+use std::task::{Context, Poll};
+
+/// A wrapper around [`tokio::sync::watch::Receiver`] that implements [`Stream`].
+///
+/// [`tokio::sync::watch::Receiver`]: struct@tokio::sync::watch::Receiver
+/// [`Stream`]: trait@crate::Stream
+pub struct WatchStream<T> {
+    inner: Pin<Box<dyn Stream<Item = ()>>>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: 'static> WatchStream<T> {
+    /// Create a new `WatchStream`.
+    pub fn new(mut rx: Receiver<T>) -> Self {
+        let stream = stream! {
+            loop {
+                match rx.changed().await {
+                    Ok(item) => yield item,
+                    Err(_) => break,
+                }
+            }
+        };
+        Self {
+            inner: Box::pin(stream),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> Stream for WatchStream<T> {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<T> fmt::Debug for WatchStream<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WatchStream").finish()
+    }
+}

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -1,7 +1,6 @@
 use crate::Stream;
 use async_stream::stream;
 use std::pin::Pin;
-use tokio::sync::watch::error::RecvError;
 use tokio::sync::watch::Receiver;
 
 use std::fmt;
@@ -41,6 +40,8 @@ impl<T> Stream for WatchStream<T> {
         Pin::new(&mut self.inner).poll_next(cx)
     }
 }
+
+impl<T> Unpin for WatchStream<T> {}
 
 impl<T> fmt::Debug for WatchStream<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
I tried to add watch the same way as the broadcast side, but now I ended up with an error like this:
```
warning: variable does not need to be mutable
  --> tokio-stream/src/wrappers/watch.rs:40:18
   |
40 |     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
   |                  ----^^^^
   |                  |
   |                  help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default

error[E0596]: cannot borrow data in a dereference of `Pin<&mut WatchStream<T>>` as mutable
  --> tokio-stream/src/wrappers/watch.rs:41:18
   |
41 |         Pin::new(&mut self.inner).poll_next(cx)
   |                  ^^^^^^^^^^^^^^^ cannot borrow as mutable
   |
   = help: trait `DerefMut` is required to modify through a dereference, but it is not implemented for `Pin<&mut WatchStream<T>>`

error: aborting due to previous error; 2 warnings emitted
```

Hopefully you can give a hand here? :)